### PR TITLE
Persist price colors and add versioned header timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,14 +20,25 @@
         }
 
         .header {
-            text-align: center;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 20px;
             margin-bottom: 30px;
         }
 
         .header h1 {
             font-size: 2.5em;
             font-weight: 300;
-            margin-bottom: 10px;
+            margin: 0;
+            display: flex;
+            align-items: center;
+        }
+
+        .version {
+            font-size: 0.5em;
+            opacity: 0.8;
+            margin-left: 10px;
         }
 
         .countdown {
@@ -178,7 +189,7 @@
 </head>
 <body>
     <div class="header">
-        <h1>Monitor de Precios BTC</h1>
+        <h1>Monitor de Precios BTC <span class="version">v1.0</span></h1>
         <div class="countdown">
             <div class="countdown-text">Próxima actualización API en:</div>
             <div class="countdown-time" id="countdownDisplay">60s</div>
@@ -306,19 +317,16 @@
         function actualizarPrecioConColor(key, price) {
             const element = elements[key].price;
             const previousPrice = preciosAnteriores[key];
-            
+
             preciosAnteriores[key] = price;
             element.textContent = `$${parseFloat(price).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}`;
             element.classList.remove('loading');
 
             if (previousPrice !== null && price !== previousPrice) {
-                element.classList.remove('up', 'down');
-                element.classList.add(price > previousPrice ? 'up' : 'down');
-                
-                // Remover clase después de 3 segundos
-                setTimeout(() => {
-                    element.classList.remove('up', 'down');
-                }, 3000);
+                const direction = price > previousPrice ? 'up' : 'down';
+                const opposite = direction === 'up' ? 'down' : 'up';
+                element.classList.remove(opposite);
+                element.classList.add(direction);
             }
         }
 


### PR DESCRIPTION
## Summary
- Keep price color until opposite variation is received
- Display update countdown next to page title with version number

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897dea772dc832da3217dd9b13d52bf