### PR TITLE
Add typing price animation, card reorder animations, lowest-price cursor and UI polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,22 +95,53 @@
         }
 
         .price-card {
-            background: rgba(255, 255, 255, 0.05);
+            background: linear-gradient(120deg, rgba(9, 17, 44, 0.85), rgba(8, 23, 56, 0.65));
             margin-bottom: 5px;
             padding: 15px;
             border-radius: 15px;
-            border: 1px solid rgba(255, 255, 255, 0.1);
-            transition: all 0.3s ease;
+            border: 1px solid rgba(125, 211, 252, 0.22);
+            transition: transform 0.55s cubic-bezier(.2, .9, .2, 1), box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
             position: relative;
+            will-change: transform;
         }
 
         .price-card:hover {
-            background: rgba(255, 255, 255, 0.1);
+            background: linear-gradient(120deg, rgba(14, 30, 70, 0.95), rgba(10, 33, 80, 0.85));
             transform: translateY(-2px);
         }
 
         .price-card:last-child {
             margin-bottom: 0;
+        }
+
+        .price-card.moving-up {
+            border-color: rgba(16, 185, 129, 0.65);
+            box-shadow: 0 0 24px rgba(16, 185, 129, 0.3);
+        }
+
+        .price-card.moving-down {
+            border-color: rgba(245, 158, 11, 0.65);
+            box-shadow: 0 0 24px rgba(245, 158, 11, 0.28);
+        }
+
+        .price-card.lowest {
+            border-color: rgba(250, 204, 21, 0.7);
+            box-shadow: 0 0 26px rgba(250, 204, 21, 0.22);
+        }
+
+        .cursor {
+            display: inline-block;
+            width: 0.62em;
+            height: 1.05em;
+            margin-left: 4px;
+            transform: translateY(3px);
+            background: #7dffb3;
+            box-shadow: 0 0 10px rgba(125, 255, 179, 0.8);
+            animation: blink 0.85s steps(1) infinite;
+        }
+
+        .cursor.off {
+            display: none;
         }
 
         .card-header {
@@ -163,6 +194,11 @@
         .loading {
             opacity: 0.5;
             animation: pulse 2s infinite;
+        }
+
+        @keyframes blink {
+            0%, 49% { opacity: 1; }
+            50%, 100% { opacity: 0; }
         }
 
         @keyframes pulse {
@@ -281,6 +317,14 @@
         // Estado global de precios
         const preciosAnteriores = {};
         const elements = {};
+        const typingTokens = {};
+        const CHARS_PER_SECOND = 25;
+        const TYPE_DELAY = 1000 / CHARS_PER_SECOND;
+
+        const cursors = {
+            api: createCursor(),
+            websocket: createCursor()
+        };
 
         // Configuración de elementos
         const config = {
@@ -289,6 +333,16 @@
         };
 
         // Inicializar elementos
+        function createCursor() {
+            const cursor = document.createElement('span');
+            cursor.className = 'cursor off';
+            return cursor;
+        }
+
+        function sleep(ms) {
+            return new Promise(resolve => setTimeout(resolve, ms));
+        }
+
         function initializeElements() {
             [...config.apis, ...config.websockets].forEach(key => {
                 elements[key] = {
@@ -296,6 +350,7 @@
                     status: document.getElementById(`${key}Status`)
                 };
                 preciosAnteriores[key] = null;
+                typingTokens[key] = 0;
             });
         }
 
@@ -313,13 +368,27 @@
             }
         }
 
-        // Actualizar precio con animación de color
-        function actualizarPrecioConColor(key, price) {
+        async function escribirPrecioGradual(element, text, token, key) {
+            element.textContent = '';
+            for (const char of text) {
+                if (typingTokens[key] !== token) return;
+                element.textContent += char;
+                await sleep(TYPE_DELAY);
+            }
+        }
+
+        // Actualizar precio con animación de color + escritura CLI (25 cps)
+        async function actualizarPrecioConColor(key, price) {
             const element = elements[key].price;
             const previousPrice = preciosAnteriores[key];
+            const formatted = `$${parseFloat(price).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}`;
 
             preciosAnteriores[key] = price;
-            element.textContent = `$${parseFloat(price).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}`;
+            const token = ++typingTokens[key];
+            await escribirPrecioGradual(element, formatted, token, key);
+
+            if (typingTokens[key] !== token) return;
+
             element.classList.remove('loading');
 
             if (previousPrice !== null && price !== previousPrice) {
@@ -339,19 +408,97 @@
             }
         }
 
-        // Ordenar cards por precio
+        function getCardsByType(containerType) {
+            return Array.from(document.getElementById(`${containerType}Container`).children);
+        }
+
+        function getNumericPriceFromCard(card) {
+            return parseFloat(elements[card.id].price.textContent.replace(/[$,]/g, ''));
+        }
+
+        function updateLowestCursor(containerType) {
+            const cards = getCardsByType(containerType);
+            const cursor = cursors[containerType];
+
+            cards.forEach(card => card.classList.remove('lowest'));
+
+            const cardsWithPrice = cards.filter(card => !Number.isNaN(getNumericPriceFromCard(card)));
+            if (!cardsWithPrice.length) {
+                cursor.classList.add('off');
+                return;
+            }
+
+            const lowestCard = cardsWithPrice.reduce((lowest, card) => (
+                getNumericPriceFromCard(card) < getNumericPriceFromCard(lowest) ? card : lowest
+            ));
+
+            lowestCard.classList.add('lowest');
+            const priceElement = elements[lowestCard.id].price;
+            cursor.classList.remove('off');
+            priceElement.appendChild(cursor);
+        }
+
+        function captureCardPositions(cards) {
+            const positions = new Map();
+            cards.forEach(card => positions.set(card, card.getBoundingClientRect()));
+            return positions;
+        }
+
+        function animateCardReorder(container, nextOrder, firstPositions) {
+            nextOrder.forEach(card => container.appendChild(card));
+
+            const lastPositions = captureCardPositions(nextOrder);
+
+            nextOrder.forEach(card => {
+                const first = firstPositions.get(card);
+                const last = lastPositions.get(card);
+                const deltaY = first.top - last.top;
+
+                card.classList.remove('moving-up', 'moving-down');
+
+                if (deltaY === 0) return;
+
+                if (deltaY > 0) {
+                    card.classList.add('moving-up');
+                } else {
+                    card.classList.add('moving-down');
+                }
+
+                card.style.transition = 'none';
+                card.style.transform = `translateY(${deltaY}px)`;
+
+                requestAnimationFrame(() => {
+                    card.style.transition = '';
+                    card.style.transform = 'translateY(0)';
+                });
+            });
+
+            setTimeout(() => {
+                nextOrder.forEach(card => card.classList.remove('moving-up', 'moving-down'));
+            }, 650);
+        }
+
+        // Ordenar cards por precio y animar sólo si cambia la posición
         function reorderCards(containerType) {
             const container = document.getElementById(`${containerType}Container`);
             const cards = Array.from(container.children);
-            
-            const sortedCards = cards.sort((a, b) => {
+            const firstPositions = captureCardPositions(cards);
+
+            const sortedCards = [...cards].sort((a, b) => {
                 const priceA = parseFloat(elements[a.id].price.textContent.replace(/[$,]/g, '')) || 0;
                 const priceB = parseFloat(elements[b.id].price.textContent.replace(/[$,]/g, '')) || 0;
                 return priceB - priceA;
             });
-            
-            container.innerHTML = '';
-            sortedCards.forEach(card => container.appendChild(card));
+
+            const orderChanged = cards.some((card, index) => card !== sortedCards[index]);
+
+            if (!orderChanged) {
+                updateLowestCursor(containerType);
+                return;
+            }
+
+            animateCardReorder(container, sortedCards, firstPositions);
+            updateLowestCursor(containerType);
         }
 
         // Fetch API data (todas las APIs de Binance + CoinGecko)
@@ -361,7 +508,7 @@
                 const response = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd');
                 const data = await response.json();
                 const price = data.bitcoin.usd;
-                actualizarPrecioConColor('coingecko', price);
+                await actualizarPrecioConColor('coingecko', price);
             } catch (error) {
                 console.error('Error fetching CoinGecko data:', error);
                 elements.coingecko.price.textContent = 'Error';
@@ -372,7 +519,7 @@
                 const response = await fetch('https://api.binance.com/api/v3/ticker/price?symbol=BTCUSDT');
                 const data = await response.json();
                 const price = parseFloat(data.price);
-                actualizarPrecioConColor('binanceAPI', price);
+                await actualizarPrecioConColor('binanceAPI', price);
             } catch (error) {
                 console.error('Error fetching Binance SPOT API data:', error);
                 elements.binanceAPI.price.textContent = 'Error';
@@ -383,7 +530,7 @@
                 const response = await fetch('https://fapi.binance.com/fapi/v1/ticker/price?symbol=BTCUSDT');
                 const data = await response.json();
                 const price = parseFloat(data.price);
-                actualizarPrecioConColor('binanceFuturesAPI', price);
+                await actualizarPrecioConColor('binanceFuturesAPI', price);
             } catch (error) {
                 console.error('Error fetching Binance Futures API data:', error);
                 elements.binanceFuturesAPI.price.textContent = 'Error';
@@ -394,7 +541,7 @@
                 const response = await fetch('https://fapi.binance.com/fapi/v1/premiumIndex?symbol=BTCUSDT');
                 const data = await response.json();
                 const price = parseFloat(data.markPrice);
-                actualizarPrecioConColor('binanceIndexAPI', price);
+                await actualizarPrecioConColor('binanceIndexAPI', price);
             } catch (error) {
                 console.error('Error fetching Binance Index API data:', error);
                 elements.binanceIndexAPI.price.textContent = 'Error';
@@ -405,7 +552,7 @@
                 const response = await fetch('https://fapi.binance.com/fapi/v1/premiumIndex?symbol=BTCUSDT');
                 const data = await response.json();
                 const price = parseFloat(data.estimatedSettlePrice);
-                actualizarPrecioConColor('binanceSettlementAPI', price);
+                await actualizarPrecioConColor('binanceSettlementAPI', price);
             } catch (error) {
                 console.error('Error fetching Binance Settlement API data:', error);
                 elements.binanceSettlementAPI.price.textContent = 'Error';
@@ -432,8 +579,7 @@
                         const data = JSON.parse(event.data);
                         const price = processData(data);
                         if (price && !isNaN(price)) {
-                            actualizarPrecioConColor(key, price);
-                            reorderCards('websocket');
+                            actualizarPrecioConColor(key, price).then(() => reorderCards('websocket'));
                         }
                     } catch (error) {
                         console.error(`Error processing ${key} data:`, error);
@@ -510,6 +656,8 @@
             initializeElements();
             fetchAPIData();
             initializeWebSockets();
+            updateLowestCursor('api');
+            updateLowestCursor('websocket');
             
             // Configurar intervalos
             setInterval(updateCountdown, 1000);


### PR DESCRIPTION
### Motivation
- Improve the visual UX of the BTC price monitor with richer visuals and clearer movement feedback.
- Make price updates feel more tactile by rendering them with a CLI-style typing animation and cancelable tokens to avoid flicker on rapid updates.
- Animate card reordering and highlight the lowest price to help users quickly spot changes across APIs and websockets.

### Description
- Enhanced CSS with gradients, hover effects, `moving-up`/`moving-down`/`lowest` classes, a blinking `.cursor`, and related keyframes and transitions to polish visuals.
- Implemented typing animation and cancellation using `TYPE_DELAY`, `typingTokens`, `escribirPrecioGradual`, and `actualizarPrecioConColor` which now awaits the gradual render and formats prices via `toLocaleString`.
- Reworked ordering to detect position changes, capture bounding rects via `captureCardPositions`, and animate reordering with `animateCardReorder`, and added `updateLowestCursor` to append the cursor to the lowest-price card.
- Updated API fetches and websocket message handling to `await` the price render before calling `reorderCards`, added `createCursor` and `sleep` helpers, and initialized lowest-cursor state during startup.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14df1f3568832d8a8f4411d70ad6d8)