### PR TITLE
Restringe escritura a 25 cps sólo en tarjetas intercambiadas y añade cursor

### DIFF
--- a/index.html
+++ b/index.html
@@ -377,18 +377,30 @@
             }
         }
 
-        // Actualizar precio con animación de color + escritura CLI (25 cps)
+        async function escribirPrecioConCursor(key, text) {
+            const element = elements[key].price;
+            const token = ++typingTokens[key];
+            const cursor = createCursor();
+            cursor.classList.remove('off');
+            element.appendChild(cursor);
+            await escribirPrecioGradual(element, text, token, key);
+            if (typingTokens[key] !== token) return;
+            element.appendChild(cursor);
+        }
+
+        function escribirPrecioInstantaneo(key, text) {
+            typingTokens[key]++;
+            elements[key].price.textContent = text;
+        }
+
+        // Actualizar precio con animación de color
         async function actualizarPrecioConColor(key, price) {
             const element = elements[key].price;
             const previousPrice = preciosAnteriores[key];
             const formatted = `$${parseFloat(price).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}`;
 
             preciosAnteriores[key] = price;
-            const token = ++typingTokens[key];
-            await escribirPrecioGradual(element, formatted, token, key);
-
-            if (typingTokens[key] !== token) return;
-
+            escribirPrecioInstantaneo(key, formatted);
             element.classList.remove('loading');
 
             if (previousPrice !== null && price !== previousPrice) {
@@ -444,7 +456,8 @@
             return positions;
         }
 
-        function animateCardReorder(container, nextOrder, firstPositions) {
+        async function animateCardReorder(containerType, container, nextOrder, firstPositions) {
+            const movedCards = [];
             nextOrder.forEach(card => container.appendChild(card));
 
             const lastPositions = captureCardPositions(nextOrder);
@@ -463,6 +476,7 @@
                 } else {
                     card.classList.add('moving-down');
                 }
+                movedCards.push(card);
 
                 card.style.transition = 'none';
                 card.style.transform = `translateY(${deltaY}px)`;
@@ -476,6 +490,16 @@
             setTimeout(() => {
                 nextOrder.forEach(card => card.classList.remove('moving-up', 'moving-down'));
             }, 650);
+
+            for (const card of movedCards) {
+                const key = card.id;
+                const price = preciosAnteriores[key];
+                if (price === null || Number.isNaN(price)) continue;
+                const formatted = `$${parseFloat(price).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+                await escribirPrecioConCursor(key, formatted);
+            }
+
+            updateLowestCursor(containerType);
         }
 
         // Ordenar cards por precio y animar sólo si cambia la posición
@@ -497,8 +521,7 @@
                 return;
             }
 
-            animateCardReorder(container, sortedCards, firstPositions);
-            updateLowestCursor(containerType);
+            animateCardReorder(containerType, container, sortedCards, firstPositions);
         }
 
         // Fetch API data (todas las APIs de Binance + CoinGecko)


### PR DESCRIPTION
### Motivation
- Evitar el efecto de tipeo global para que los cambios de precio sin reordenamiento se muestren instantáneamente y estables. 
- Mantener el efecto de escritura a 25 cps únicamente en las tarjetas que realmente cambian de posición y hacer que un cursor visual las acompañe.

### Description
- Añadí `escribirPrecioConCursor` para realizar la escritura gradual con cursor y `escribirPrecioInstantaneo` para actualizaciones inmediatas; ambas nuevas funciones viven en `index.html`.
- Cambié `actualizarPrecioConColor` para usar `escribirPrecioInstantaneo` en lugar de la escritura gradual, preservando la lógica de color `up/down` y el flag `loading`.
- Convertí `animateCardReorder` en una función `async` que recibe `containerType` y ahora detecta `movedCards`; tras animar el reordenamiento, llama a `escribirPrecioConCursor` solo para las tarjetas intercambiadas.
- Actualicé `reorderCards` para delegar a la nueva firma de `animateCardReorder` y mantener la actualización del cursor de menor precio cuando no hay cambios de orden.

### Testing
- No se ejecutaron pruebas automatizadas sobre el cambio; los pasos realizados fueron la aplicación del parche y el commit del archivo modificado (`index.html`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e26c0134832d9bd6ad0a12d49233)