### PR TITLE
Ajusta el cursor cuando no hay intercambio de tarjetas

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,7 +425,8 @@
         }
 
         function getNumericPriceFromCard(card) {
-            return parseFloat(elements[card.id].price.textContent.replace(/[$,]/g, ''));
+            const price = Number(preciosAnteriores[card.id]);
+            return Number.isFinite(price) ? price : NaN;
         }
 
         function getMovedCards(currentOrder, nextOrder) {
@@ -482,6 +483,31 @@
             lowestMovedCard.classList.add('lowest');
 
             const priceElement = elements[lowestMovedCard.id].price;
+            priceElement.appendChild(cursor);
+            cursor.classList.remove('off');
+        }
+
+        function updateCursorEnTarjetaInferior(containerType) {
+            const cursor = cursors[containerType];
+            const cards = getCardsByType(containerType);
+
+            cards.forEach(card => {
+                card.classList.remove('lowest');
+            });
+
+            const cardsWithPrice = cards.filter(card => {
+                return !Number.isNaN(getNumericPriceFromCard(card));
+            });
+
+            if (!cardsWithPrice.length) {
+                cursor.classList.add('off');
+                return;
+            }
+
+            const bottomCard = cardsWithPrice[cardsWithPrice.length - 1];
+            const priceElement = elements[bottomCard.id].price;
+
+            bottomCard.classList.add('lowest');
             priceElement.appendChild(cursor);
             cursor.classList.remove('off');
         }
@@ -558,6 +584,8 @@
             });
 
             if (!cardsWithPrice.length) {
+                const cursor = cursors[containerType];
+                cursor.classList.add('off');
                 return;
             }
 
@@ -576,6 +604,7 @@
             const movedCards = getMovedCards(cards, sortedCards);
 
             if (!movedCards.length) {
+                updateCursorEnTarjetaInferior(containerType);
                 return;
             }
 
@@ -749,8 +778,8 @@
             initializeElements();
             fetchAPIData();
             initializeWebSockets();
-            updateCursorSoloEnMovidas('api', getCardsByType('api'));
-            updateCursorSoloEnMovidas('websocket', getCardsByType('websocket'));
+            updateCursorEnTarjetaInferior('api');
+            updateCursorEnTarjetaInferior('websocket');
             
             // Configurar intervalos
             setInterval(updateCountdown, 1000);


### PR DESCRIPTION
### Motivation
- Evitar que el panel entre en un “estado quieto” donde el cursor no refleja correctamente la última tarjeta visible cuando no hubo intercambio de posiciones. 
- Separar visualmente el evento de intercambio (animación de tarjetas movidas) del estado estable (cursor parpadeando en la última tarjeta válida).
- Evitar lecturas frágiles del DOM durante la escritura/parpadeo usando valores almacenados en `preciosAnteriores`.

### Description
- Reemplaza `getNumericPriceFromCard(card)` para leer el precio desde `preciosAnteriores` y devolver `NaN` si no hay valor numérico válido. 
- Añade `updateCursorEnTarjetaInferior(containerType)` que ubica el cursor en la última tarjeta con precio válido o lo apaga si no existen precios válidos. 
- Modifica `reorderCards(containerType)` para que cuando no haya tarjetas movidas (`movedCards.length === 0`) se llame a `updateCursorEnTarjetaInferior(containerType)` en lugar de salir sin ajustar el cursor, y para apagar el cursor si no hay precios en la columna. 
- Cambia la inicialización para usar `updateCursorEnTarjetaInferior('api')` y `updateCursorEnTarjetaInferior('websocket')` en vez de simular que todas las tarjetas fueron movidas al iniciar, preservando la nueva regla visual.

### Testing
- Ejecutado `git diff --check` y no reportó problemas. 
- Verificada la lista de archivos modificados en el árbol de trabajo sin cambios inesperados. 
- Se generó la metadata del PR correctamente a partir de los cambios aplicados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e86590cc832d9086a4fe4eb03bbc)