### PR TITLE
Ajusta parpadeo y estabilidad de hover en monitor BTC

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,11 +107,6 @@
 
         .price-card:hover {
             background: linear-gradient(120deg, rgba(14, 30, 70, 0.95), rgba(10, 33, 80, 0.85));
-            transform: translateY(-2px);
-        }
-
-        .is-reordering .price-card:hover {
-            transform: none;
         }
 
         .price-card:last-child {
@@ -196,7 +191,7 @@
         }
 
         .blinking-price {
-            animation: blink-price 0.55s ease-in-out infinite;
+            animation: blink-price 0.2s steps(1, end) infinite;
         }
 
         .loading {
@@ -216,8 +211,15 @@
         }
 
         @keyframes blink-price {
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.35; }
+            0%, 49% {
+                color: inherit;
+                text-shadow: inherit;
+            }
+
+            50%, 100% {
+                color: rgba(10, 30, 20, 0.95);
+                text-shadow: none;
+            }
         }
 
         @media (max-width: 768px) {
@@ -814,7 +816,6 @@
             
             // Configurar intervalos
             setInterval(updateCountdown, 1000);
-            setInterval(fetchAPIData, 60000); // Cada minuto
         }
 
         // Iniciar aplicación


### PR DESCRIPTION
### Motivation
- Evitar transiciones suaves de opacidad que causaban parpadeos visuales indeseados al resaltar precios. 
- Eliminar micro-saltos durante hover en `.price-card` provocados por `transform: translateY(-2px)` en combinaciones con reordenamiento. 
- Evitar actualizaciones duplicadas de datos cuando el contador y un `setInterval` llaman a la misma función de refresh.

### Description
- Modifiqué `index.html` para reemplazar la animación de `.blinking-price` con `animation: blink-price 0.2s steps(1, end) infinite;` para un parpadeo por pasos. 
- Reescribí `@keyframes blink-price` para alternar `color` y `text-shadow` en lugar de usar `opacity`, de modo que el “apagado” visual no dependa de la opacidad. 
- Eliminé `transform: translateY(-2px)` del selector `.price-card:hover` y quité la regla auxiliar `.is-reordering .price-card:hover` porque ya no es necesaria. 
- Eliminé la llamada periódica `setInterval(fetchAPIData, 60000)` dejando que el contador (`updateCountdown`) sea el responsable de invocar `fetchAPIData()` al llegar a cero.

### Testing
- Ejecuté búsquedas con `rg` para verificar que `@keyframes blink-price`, `.blinking-price`, `.price-card:hover` y `setInterval(fetchAPIData` reflejan los cambios esperados, y la búsqueda encontró las nuevas definiciones correctamente. 
- Verifiqué el estado de git con `git status --short` y realicé el commit con `git commit`, ambos completados sin errores. 
- Confirmé manualmente que `index.html` quedó modificado y que la entrada duplicada de `setInterval(fetchAPIData, 60000)` fue removida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14efe338a0832d8f90a6177803fdd0)