### PR TITLE
Refactor: BTC card reorder choreography and strict two-color price rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,21 +177,22 @@
             font-size: 1.8em;
             font-weight: 700;
             text-align: center;
-            transition: all 0.3s ease;
-        }
-
-        .up {
             color: #10b981;
-            text-shadow: 0 0 10px rgba(16, 185, 129, 0.3);
+            transition: text-shadow 0.2s ease;
         }
 
-        .down {
+        .price.up {
+            color: #10b981;
+            text-shadow: 0 0 10px rgba(16, 185, 129, 0.45);
+        }
+
+        .price.down {
             color: #ef4444;
-            text-shadow: 0 0 10px rgba(239, 68, 68, 0.3);
+            text-shadow: 0 0 10px rgba(239, 68, 68, 0.45);
         }
 
         .blinking-price {
-            animation: blink-price 0.2s steps(1, end) infinite;
+            animation: finalPriceFlash 0.2s steps(1, end) 5;
         }
 
         .loading {
@@ -210,14 +211,14 @@
             100% { opacity: 0.5; }
         }
 
-        @keyframes blink-price {
+        @keyframes finalPriceFlash {
             0%, 49% {
-                color: inherit;
-                text-shadow: inherit;
+                text-shadow:
+                    0 0 8px currentColor,
+                    0 0 18px currentColor;
             }
 
             50%, 100% {
-                color: rgba(10, 30, 20, 0.95);
                 text-shadow: none;
             }
         }
@@ -336,7 +337,6 @@
         const CHARS_PER_SECOND = 25;
         const TYPE_DELAY = 1000 / CHARS_PER_SECOND;
         const reorderLocks = { api: false, websocket: false };
-        const colorResetTimers = {};
 
         const cursors = {
             api: createCursor(),
@@ -384,59 +384,96 @@
                 fetchAPIData();
             }
         }
-        async function escribirPrecioConCursor(containerType, key, text) {
+        function formatPrice(price) {
+            return `$${Number(price).toLocaleString('en-US', {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+            })}`;
+        }
+
+        function aplicarColorPrecio(key, nextPrice) {
+            const element = elements[key].price;
+            const previousRendered = Number(element.dataset.renderedPrice);
+
+            element.classList.remove('up', 'down');
+
+            if (!Number.isFinite(previousRendered)) {
+                element.classList.add('up');
+                return;
+            }
+
+            if (Number(nextPrice) >= previousRendered) {
+                element.classList.add('up');
+            } else {
+                element.classList.add('down');
+            }
+        }
+
+        async function actualizarPrecioConColor(key, price, renderNow = true) {
+            const numericPrice = Number(price);
+
+            if (!Number.isFinite(numericPrice)) return;
+
+            preciosAnteriores[key] = numericPrice;
+
+            if (!renderNow) return;
+
+            const element = elements[key].price;
+
+            aplicarColorPrecio(key, numericPrice);
+
+            typingTokens[key]++;
+            element.textContent = formatPrice(numericPrice);
+            element.dataset.renderedPrice = String(numericPrice);
+            element.classList.remove('loading');
+        }
+
+        async function escribirPrecioConCursor(containerType, key, price) {
             const element = elements[key].price;
             const token = ++typingTokens[key];
             const cursor = cursors[containerType];
+            const text = formatPrice(price);
 
-            cursor.classList.add('off');
+            aplicarColorPrecio(key, price);
+
+            cursor.classList.remove('off');
             element.textContent = '';
+            element.appendChild(cursor);
 
             for (const char of text) {
                 if (typingTokens[key] !== token) return;
+
+                cursor.remove();
                 element.textContent += char;
+                element.appendChild(cursor);
+
                 await sleep(TYPE_DELAY);
             }
 
             if (typingTokens[key] !== token) return;
 
-            element.appendChild(cursor);
+            element.dataset.renderedPrice = String(price);
+            element.classList.remove('loading');
             cursor.classList.remove('off');
         }
 
-        function escribirPrecioInstantaneo(key, text) {
-            typingTokens[key]++;
-            elements[key].price.textContent = text;
-        }
-
-        // Actualizar precio con animación de color
-        async function actualizarPrecioConColor(key, price) {
+        async function destellarYBorrarPrecio(containerType, card) {
+            const key = card.id;
             const element = elements[key].price;
-            const previousPrice = preciosAnteriores[key];
-            const formatted = `$${parseFloat(price).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}`;
+            const cursor = cursors[containerType];
 
-            preciosAnteriores[key] = price;
-            escribirPrecioInstantaneo(key, formatted);
-            element.classList.remove('loading');
+            cursor.classList.remove('off');
+            element.appendChild(cursor);
 
-            if (colorResetTimers[key]) {
-                clearTimeout(colorResetTimers[key]);
-                colorResetTimers[key] = null;
-            }
+            element.classList.add('blinking-price');
 
-            if (previousPrice !== null && price !== previousPrice) {
-                const direction = price > previousPrice ? 'up' : 'down';
-                const opposite = direction === 'up' ? 'down' : 'up';
-                element.classList.remove(opposite);
-                element.classList.add(direction);
+            await sleep(1000);
 
-                colorResetTimers[key] = setTimeout(() => {
-                    element.classList.remove('up', 'down');
-                    colorResetTimers[key] = null;
-                }, 1100);
-            } else if (previousPrice !== null) {
-                element.classList.remove('up', 'down');
-            }
+            element.classList.remove('blinking-price');
+
+            cursor.remove();
+            element.textContent = '';
+            element.appendChild(cursor);
         }
 
         // Actualizar estado de conexión
@@ -548,8 +585,21 @@
 
         async function animateCardReorder(containerType, container, nextOrder, firstPositions, movedCards) {
             container.classList.add('is-reordering');
+
             try {
-                await parpadearMenorEntreTarjetasMovidas(containerType, movedCards, 1000);
+                const movedCardsWithPrice = movedCards.filter(card => {
+                    return Number.isFinite(getNumericPriceFromCard(card));
+                });
+
+                if (!movedCardsWithPrice.length) return;
+
+                const cardsToErase = [...movedCardsWithPrice].sort((a, b) => {
+                    return getNumericPriceFromCard(a) - getNumericPriceFromCard(b);
+                });
+
+                for (const card of cardsToErase) {
+                    await destellarYBorrarPrecio(containerType, card);
+                }
 
                 nextOrder.forEach(card => container.appendChild(card));
 
@@ -581,25 +631,24 @@
 
                 await sleep(650);
 
-                movedCards.forEach(card => {
+                nextOrder.forEach(card => {
                     card.classList.remove('moving-up', 'moving-down');
                 });
 
-                for (const card of movedCards) {
+                const cardsToWrite = [...movedCardsWithPrice].sort((a, b) => {
+                    return getNumericPriceFromCard(b) - getNumericPriceFromCard(a);
+                });
+
+                for (const card of cardsToWrite) {
                     const key = card.id;
                     const price = preciosAnteriores[key];
 
-                    if (price === null || Number.isNaN(Number(price))) continue;
+                    if (!Number.isFinite(Number(price))) continue;
 
-                    const formatted = `$${Number(price).toLocaleString('en-US', {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2
-                    })}`;
-
-                    await escribirPrecioConCursor(containerType, key, formatted);
+                    await escribirPrecioConCursor(containerType, key, price);
                 }
 
-                updateCursorSoloEnMovidas(containerType, movedCards);
+                updateCursorSoloEnMovidas(containerType, movedCardsWithPrice);
             } finally {
                 container.classList.remove('is-reordering');
             }
@@ -637,6 +686,18 @@
             const movedCards = getMovedCards(cards, sortedCards);
 
             if (!movedCards.length) {
+                for (const card of cardsWithPrice) {
+                    const key = card.id;
+                    const price = preciosAnteriores[key];
+                    const element = elements[key].price;
+
+                    aplicarColorPrecio(key, price);
+                    typingTokens[key]++;
+                    element.textContent = formatPrice(price);
+                    element.dataset.renderedPrice = String(price);
+                    element.classList.remove('loading');
+                }
+
                 updateCursorEnTarjetaInferior(containerType);
                 return;
             }
@@ -663,7 +724,7 @@
                 const response = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd');
                 const data = await response.json();
                 const price = data.bitcoin.usd;
-                await actualizarPrecioConColor('coingecko', price);
+                await actualizarPrecioConColor('coingecko', price, false);
             } catch (error) {
                 console.error('Error fetching CoinGecko data:', error);
                 elements.coingecko.price.textContent = 'Error';
@@ -674,7 +735,7 @@
                 const response = await fetch('https://api.binance.com/api/v3/ticker/price?symbol=BTCUSDT');
                 const data = await response.json();
                 const price = parseFloat(data.price);
-                await actualizarPrecioConColor('binanceAPI', price);
+                await actualizarPrecioConColor('binanceAPI', price, false);
             } catch (error) {
                 console.error('Error fetching Binance SPOT API data:', error);
                 elements.binanceAPI.price.textContent = 'Error';
@@ -685,7 +746,7 @@
                 const response = await fetch('https://fapi.binance.com/fapi/v1/ticker/price?symbol=BTCUSDT');
                 const data = await response.json();
                 const price = parseFloat(data.price);
-                await actualizarPrecioConColor('binanceFuturesAPI', price);
+                await actualizarPrecioConColor('binanceFuturesAPI', price, false);
             } catch (error) {
                 console.error('Error fetching Binance Futures API data:', error);
                 elements.binanceFuturesAPI.price.textContent = 'Error';
@@ -696,7 +757,7 @@
                 const response = await fetch('https://fapi.binance.com/fapi/v1/premiumIndex?symbol=BTCUSDT');
                 const data = await response.json();
                 const price = parseFloat(data.markPrice);
-                await actualizarPrecioConColor('binanceIndexAPI', price);
+                await actualizarPrecioConColor('binanceIndexAPI', price, false);
             } catch (error) {
                 console.error('Error fetching Binance Index API data:', error);
                 elements.binanceIndexAPI.price.textContent = 'Error';
@@ -707,13 +768,13 @@
                 const response = await fetch('https://fapi.binance.com/fapi/v1/premiumIndex?symbol=BTCUSDT');
                 const data = await response.json();
                 const price = parseFloat(data.estimatedSettlePrice);
-                await actualizarPrecioConColor('binanceSettlementAPI', price);
+                await actualizarPrecioConColor('binanceSettlementAPI', price, false);
             } catch (error) {
                 console.error('Error fetching Binance Settlement API data:', error);
                 elements.binanceSettlementAPI.price.textContent = 'Error';
             }
 
-            reorderCards('api');
+            await reorderCards('api');
         }
 
         // Setup WebSocket
@@ -734,7 +795,7 @@
                         const data = JSON.parse(event.data);
                         const price = processData(data);
                         if (price && !isNaN(price)) {
-                            actualizarPrecioConColor(key, price).then(() => reorderCards('websocket'));
+                            actualizarPrecioConColor(key, price, false).then(() => reorderCards('websocket'));
                         }
                     } catch (error) {
                         console.error(`Error processing ${key} data:`, error);


### PR DESCRIPTION
### Motivation
- Asegurar una coreografía determinista para los intercambios de tarjetas que congele la vista hasta decidir reordenar y aplicar el borrado/tipeo solo a las tarjetas movidas. 
- Forzar que el texto de precio use únicamente dos colores (verde/rojo) y que el destello final no cambie el color del texto sino solo `text-shadow`.

### Description
- Ajustes CSS para `.price`, `.price.up`, `.price.down`, `.blinking-price` y `@keyframes` para dejar `color` exclusivo en verde/rojo y reemplazar el blink por `text-shadow` con `currentColor` a `0.2s steps(1, end) 5`.
- Nuevas utilidades `formatPrice(price)` y `aplicarColorPrecio(key, nextPrice)` y cambio de `actualizarPrecioConColor` para aceptar `renderNow` y guardar los valores en `preciosAnteriores` sin renderizar cuando `renderNow=false`.
- Reemplazo de la escritura con cursor: `escribirPrecioConCursor(containerType, key, price)` ahora recibe un precio numérico, escribe `formatPrice(price)` carácter a carácter, mantiene un único cursor por columna y actualiza `dataset.renderedPrice` al finalizar.
- Se añadió `destellarYBorrarPrecio(containerType, card)` y se reescribió `animateCardReorder(...)` para: filtrar solo movidas con precio, borrar (destello) primero la menor (orden ascendente), hacer el `appendChild` con `nextOrder` y aplicar FLIP, esperar la animación, escribir los precios nuevos solo en las tarjetas movidas en orden descendente, y actualizar el cursor únicamente en movidas.
- `reorderCards(containerType)` fue modificado para usar `preciosAnteriores` como fuente numérica, renderizar inmediatamente cuando no hay movedCards (sin borrar/tipear en tarjetas no movidas) y usar `reorderLocks` + la nueva `animateCardReorder` cuando hay movimiento.
- `fetchAPIData()` y `setupWebSocket()` ahora llaman `actualizarPrecioConColor(..., false)` para almacenar primero los precios y luego invocar `reorderCards('api'|'websocket')`, preservando la coreografía y evitando render prematuro.

### Testing
- Validación de sintaxis del script embebido con Node usando `new Function(...)` sobre el contenido de `<script>` en `index.html`, que se ejecutó correctamente (resultado: `ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14f6333cc0832d8e0318b6d286e145)