### PR TITLE
Preserve card dimensions when erasing prices and synchronize cursor blink

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,6 +181,19 @@
             transition: text-shadow 0.2s ease;
         }
 
+
+        .price {
+            min-height: 1.2em;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .price.is-erased {
+            color: transparent !important;
+            text-shadow: none !important;
+        }
+
         .price.up {
             color: #10b981;
             text-shadow: 0 0 10px rgba(16, 185, 129, 0.45);
@@ -336,6 +349,7 @@
         const typingTokens = {};
         const CHARS_PER_SECOND = 25;
         const TYPE_DELAY = 1000 / CHARS_PER_SECOND;
+        const CURSOR_BLINK_DURATION_SECONDS = 0.85;
         const reorderLocks = { api: false, websocket: false };
 
         const cursors = {
@@ -353,6 +367,8 @@
         function createCursor() {
             const cursor = document.createElement('span');
             cursor.className = 'cursor off';
+            const nowSeconds = Date.now() / 1000;
+            cursor.style.animationDelay = `-${(nowSeconds % CURSOR_BLINK_DURATION_SECONDS).toFixed(3)}s`;
             return cursor;
         }
 
@@ -425,7 +441,7 @@
             typingTokens[key]++;
             element.textContent = formatPrice(numericPrice);
             element.dataset.renderedPrice = String(numericPrice);
-            element.classList.remove('loading');
+            element.classList.remove('loading', 'is-erased');
         }
 
         async function escribirPrecioConCursor(containerType, key, price) {
@@ -435,6 +451,8 @@
             const text = formatPrice(price);
 
             aplicarColorPrecio(key, price);
+
+            element.classList.remove('is-erased');
 
             cursor.classList.remove('off');
             element.textContent = '';
@@ -453,7 +471,7 @@
             if (typingTokens[key] !== token) return;
 
             element.dataset.renderedPrice = String(price);
-            element.classList.remove('loading');
+            element.classList.remove('loading', 'is-erased');
             cursor.classList.remove('off');
         }
 
@@ -472,7 +490,7 @@
             element.classList.remove('blinking-price');
 
             cursor.remove();
-            element.textContent = '';
+            element.classList.add('is-erased');
             element.appendChild(cursor);
         }
 
@@ -695,7 +713,7 @@
                     typingTokens[key]++;
                     element.textContent = formatPrice(price);
                     element.dataset.renderedPrice = String(price);
-                    element.classList.remove('loading');
+                    element.classList.remove('loading', 'is-erased');
                 }
 
                 updateCursorEnTarjetaInferior(containerType);


### PR DESCRIPTION
### Motivation
- Evitar que las tarjetas cambien de tamaño durante reordenamientos cuando se borra un precio y prevenir parpadeos visuales que distraigan la lectura. 
- Hacer que el parpadeo del cursor entre feeds (API y WebSocket) esté alineado en fase sin ligar su frecuencia a la cadencia de actualización de precios en tiempo real. 
- Mantener la UX consistente mostrando el cursor mientras el valor está oculto, pero preservando la huella visual del elemento de precio.

### Description
- Se añadió a la hoja de estilos una huella estable para ` .price` (`min-height` y centrado con `flex`) para evitar colapsos de altura y se agregó la clase ` .price.is-erased` para ocultar visualmente el texto sin vaciar el contenido. 
- Se introdujo la constante `CURSOR_BLINK_DURATION_SECONDS` y al crear cada cursor en `createCursor()` se fija `animationDelay` usando la misma referencia temporal para sincronizar la fase de parpadeo entre cursors. 
- En la lógica de renderizado se limpia/evita la clase `is-erased` al volver a pintar precios en `escribirPrecioConCursor()` y `actualizarPrecioConColor()`, y se usa `is-erased` en `destellarYBorrarPrecio()` en lugar de dejar `textContent = ''` para preservar dimensiones. 
- Se actualizaron rutas de reordenado/renderado para eliminar `is-erased` en los caminos directos y de tipeo y para mantener las transiciones/animaciones existentes (`reorderCards`, `animateCardReorder`).

### Testing
- Se ejecutaron inspecciones y ediciones automatizadas sobre el archivo con `sed`, `nl`, y el script `python - <<'PY' ...` para aplicar y verificar los cambios de `index.html`, y todas las operaciones de edición y visualización terminaron correctamente. 
- Se verificó el diff con `git diff -- index.html` y se realizó el `git commit` con el mensaje correspondiente, ambos completados sin errores. 
- No existe una suite de pruebas automatizadas en este repositorio, por lo que las validaciones fueron revisiones de código y comprobaciones de archivo automatizadas y manuales que resultaron exitosas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14f7f6ce5c832d899896e59e0934dd)