### PR TITLE
Añadir debounce a reordenamientos de tarjetas (API / WebSocket)

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,6 +347,8 @@
         const TYPE_DELAY = 1000 / CHARS_PER_SECOND;
         const CURSOR_BLINK_DURATION_SECONDS = 0.85;
         const reorderLocks = { api: false, websocket: false };
+        const debounceReorders = { api: null, websocket: null };
+        const DEBOUNCE_DELAY = 160;
 
         const cursors = {
             api: createCursor(),
@@ -370,6 +372,17 @@
 
         function sleep(ms) {
             return new Promise(resolve => setTimeout(resolve, ms));
+        }
+
+        function debouncedReorder(containerType) {
+            if (debounceReorders[containerType]) {
+                clearTimeout(debounceReorders[containerType]);
+            }
+
+            debounceReorders[containerType] = setTimeout(() => {
+                reorderCards(containerType);
+                debounceReorders[containerType] = null;
+            }, DEBOUNCE_DELAY);
         }
 
         function initializeElements() {
@@ -788,7 +801,7 @@
                 elements.binanceSettlementAPI.price.textContent = 'Error';
             }
 
-            await reorderCards('api');
+            debouncedReorder('api');
         }
 
         // Setup WebSocket
@@ -809,7 +822,9 @@
                         const data = JSON.parse(event.data);
                         const price = processData(data);
                         if (price && !isNaN(price)) {
-                            actualizarPrecioConColor(key, price, false).then(() => reorderCards('websocket'));
+                            actualizarPrecioConColor(key, price, false).then(() => {
+                                debouncedReorder('websocket');
+                            });
                         }
                     } catch (error) {
                         console.error(`Error processing ${key} data:`, error);


### PR DESCRIPTION
### Motivation
- Evitar animaciones y reordenamientos repetidos provocados por ráfagas de actualizaciones (especialmente desde WebSockets) que generan parpadeo y jitter en la UI.
- Consolidar múltiples solicitudes de reordenamiento en una sola ejecución diferida para suavizar la experiencia visual.

### Description
- Añadido estado global de debounce `debounceReorders` y constante `DEBOUNCE_DELAY` (`160` ms) para los contenedores `api` y `websocket`.
- Implementada la función `debouncedReorder(containerType)` que cancela timeouts previos y programa una única llamada a `reorderCards` tras el retraso.
- Reemplazada la llamada inmediata `reorderCards('api')` al final de `fetchAPIData()` por `debouncedReorder('api')`.
- Reemplazado el reordenamiento inmediato en `ws.onmessage` por `debouncedReorder('websocket')` tras actualizar el precio.

### Testing
- No existe una suite de pruebas automatizadas en este repositorio, por lo que no se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14fe36fb78832da32358b9d57d32fe)