### PR TITLE
Fix irregular websocket cursor blinking by using CSS pseudo-element

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,19 +128,16 @@
             box-shadow: 0 0 26px rgba(250, 204, 21, 0.22);
         }
 
-        .cursor {
+        .cursor-target .price::after {
+            content: '';
             display: inline-block;
             width: 0.62em;
             height: 1.05em;
             margin-left: 4px;
-            transform: translateY(3px);
+            vertical-align: -3px;
             background: #7dffb3;
             box-shadow: 0 0 10px rgba(125, 255, 179, 0.8);
             animation: blink 0.85s steps(1) infinite;
-        }
-
-        .cursor.off {
-            display: none;
         }
 
         .card-header {
@@ -345,15 +342,9 @@
         const typingTokens = {};
         const CHARS_PER_SECOND = 25;
         const TYPE_DELAY = 1000 / CHARS_PER_SECOND;
-        const CURSOR_BLINK_DURATION_SECONDS = 0.85;
         const reorderLocks = { api: false, websocket: false };
         const debounceReorders = { api: null, websocket: null };
         const DEBOUNCE_DELAY = 160;
-
-        const cursors = {
-            api: createCursor(),
-            websocket: createCursor()
-        };
 
         // Configuración de elementos
         const config = {
@@ -362,14 +353,6 @@
         };
 
         // Inicializar elementos
-        function createCursor() {
-            const cursor = document.createElement('span');
-            cursor.className = 'cursor off';
-            const nowSeconds = Date.now() / 1000;
-            cursor.style.animationDelay = `-${(nowSeconds % CURSOR_BLINK_DURATION_SECONDS).toFixed(3)}s`;
-            return cursor;
-        }
-
         function sleep(ms) {
             return new Promise(resolve => setTimeout(resolve, ms));
         }
@@ -456,23 +439,15 @@
         async function escribirPrecioConCursor(containerType, key, price) {
             const element = elements[key].price;
             const token = ++typingTokens[key];
-            const cursor = cursors[containerType];
             const text = formatPrice(price);
 
             aplicarColorPrecio(key, price);
-
-            
-            cursor.classList.remove('off');
             element.textContent = '';
-            element.appendChild(cursor);
 
             for (const char of text) {
                 if (typingTokens[key] !== token) return;
 
-                cursor.remove();
                 element.textContent += char;
-                element.appendChild(cursor);
-
                 await sleep(TYPE_DELAY);
             }
 
@@ -480,27 +455,16 @@
 
             element.dataset.renderedPrice = String(price);
             element.classList.remove('loading');
-            cursor.classList.remove('off');
         }
 
         async function destellarYBorrarPrecio(containerType, card) {
             const key = card.id;
             const element = elements[key].price;
-            const cursor = cursors[containerType];
-
-            cursor.classList.remove('off');
-            element.appendChild(cursor);
 
             element.classList.add('blinking-price');
-
             await sleep(1000);
-
             element.classList.remove('blinking-price');
-
-            cursor.remove();
             element.textContent = '';
-            element.appendChild(cursor);
-            cursor.classList.remove('off');
         }
 
         // Actualizar estado de conexión
@@ -526,8 +490,6 @@
         }
 
         async function parpadearMenorEntreTarjetasMovidas(containerType, movedCards, duration = 1000) {
-            const cursor = cursors[containerType];
-
             const movedCardsWithPrice = movedCards.filter(card => {
                 return !Number.isNaN(getNumericPriceFromCard(card));
             });
@@ -542,7 +504,6 @@
 
             const priceElement = elements[lowestMovedCard.id].price;
 
-            cursor.classList.add('off');
             priceElement.classList.add('blinking-price');
 
             await sleep(duration);
@@ -551,8 +512,6 @@
         }
 
         function updateCursorSoloEnMovidas(containerType, movedCards) {
-            const cursor = cursors[containerType];
-
             getCardsByType(containerType).forEach(card => {
                 card.classList.remove('cursor-target');
             });
@@ -561,10 +520,7 @@
                 return !Number.isNaN(getNumericPriceFromCard(card));
             });
 
-            if (!movedCardsWithPrice.length) {
-                cursor.classList.add('off');
-                return;
-            }
+            if (!movedCardsWithPrice.length) return;
 
             const lowestMovedCard = movedCardsWithPrice.reduce((lowest, card) => {
                 return getNumericPriceFromCard(card) < getNumericPriceFromCard(lowest)
@@ -573,14 +529,9 @@
             });
 
             lowestMovedCard.classList.add('cursor-target');
-
-            const priceElement = elements[lowestMovedCard.id].price;
-            priceElement.appendChild(cursor);
-            cursor.classList.remove('off');
         }
 
         function updateCursorEnTarjetaInferior(containerType) {
-            const cursor = cursors[containerType];
             const cards = getCardsByType(containerType);
 
             cards.forEach(card => {
@@ -591,17 +542,9 @@
                 return !Number.isNaN(getNumericPriceFromCard(card));
             });
 
-            if (!cardsWithPrice.length) {
-                cursor.classList.add('off');
-                return;
-            }
+            if (!cardsWithPrice.length) return;
 
-            const bottomCard = cardsWithPrice[cardsWithPrice.length - 1];
-            const priceElement = elements[bottomCard.id].price;
-
-            bottomCard.classList.add('cursor-target');
-            priceElement.appendChild(cursor);
-            cursor.classList.remove('off');
+            cardsWithPrice[cardsWithPrice.length - 1].classList.add('cursor-target');
         }
 
         function captureCardPositions(cards) {
@@ -692,11 +635,7 @@
                 return !Number.isNaN(getNumericPriceFromCard(card));
             });
 
-            if (!cardsWithPrice.length) {
-                const cursor = cursors[containerType];
-                cursor.classList.add('off');
-                return;
-            }
+            if (!cardsWithPrice.length) return;
 
             const firstPositions = captureCardPositions(cards);
 


### PR DESCRIPTION
### Motivation
- The shared DOM cursor node was being moved with `appendChild` on every price update and character typed, which restarted the CSS blink animation and produced irregular flicker under high-frequency websocket updates.
- The goal is to make the cursor blink continuous and stable by avoiding re-mounting a DOM node during updates and reorders.

### Description
- Replaced the movable `.cursor` element with a CSS pseudo-element at `.cursor-target .price::after` and removed the `.cursor.off` handling in CSS. 
- Removed shared JS cursor state (`cursors`, `createCursor`) and the `CURSOR_BLINK_DURATION_SECONDS` constant so code no longer creates or moves a cursor DOM node. 
- Simplified `escribirPrecioConCursor` to only type the price characters into the `.price` element without removing/appending any cursor node. 
- Removed cursor DOM manipulations from `destellarYBorrarPrecio`, `parpadearMenorEntreTarjetasMovidas`, `updateCursorSoloEnMovidas`, `updateCursorEnTarjetaInferior`, and adjusted `reorderCards` early exits to stop referencing the removed cursor. 

### Testing
- Ran `git diff --check` which passed without whitespace errors. 
- Searched with `rg -n "cursor|CURSOR_BLINK|createCursor|cursors" index.html` to verify DOM cursor usage was removed and CSS/class-based cursor remains. 
- Committed the change and created the PR; commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1501a209a4832db5941779b5f8e0f2)